### PR TITLE
SSE-1317: test types are not being returned for some alerts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # vs code
 .vscode
+
+# pycharm
+.idea

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='thousandeyessdk',
-    version='0.0.6a7',
+    version='0.0.6a8',
     description='Python SDK for ThousandEyes API Monitoring Service',
     long_description="Python SDK for ThousandEyes API Monitoring Service",
     long_description_content_type='text/markdown',

--- a/thousandeyessdk/alert.py
+++ b/thousandeyessdk/alert.py
@@ -1,7 +1,5 @@
 from .alert_rule import AlertRule
 from .core.base_entity import BaseEntity
-from .enum import AlertType
-from .agent import Agent
 from .test import Test
 
 
@@ -107,23 +105,22 @@ class Alert(BaseEntity):
     def type(self):
         """This is property to get type of the alert
         
-        :return: Enum name-value pair from AlertType class (refer to enum.py module) 
-            original type value of alert object can be returned using "string_type" property
-        :rtype: enum 'AlertType'
+        :return: This is property to get type of the alert
+        :rtype: string
  
         example: for ThousandEyes alert object containing:
         {
             "type": "HTTP Server"
         }
-        returns enum: <AlertType.HTTP_SERVER: 'HTTP Server'>
-        to access enum name use: "alert.type.name" which returns string: "AlertType.HTTP_SERVER"
-        to access enum value use: "alert.type.value" which returns string: "HTTP Server" (equivalent to 'string_type' property)
+        returns enum: "HTTP Server"
         """
-        return AlertType.get(self._data.get('type'))
+        return self._data.get('type')
 
     @property
     def string_type(self):
-        """This is property to get type of the alert
+        """DEPRECATED. This is property to get type of the alert.
+        It returns the same value as type(self) but due to the
+        compatibility reason it remains untouched.
         
         :return: value of "type" key
         :rtype: string


### PR DESCRIPTION
There is no need to keep test types in a limited enum. It requires to maintain the enum and add new types if needed. SpongeBob decided to resign from this approach during one of the architecture review.