### PR TITLE
SSE-1527: testTargetsDescription not valid to alert object

### DIFF
--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -21,9 +21,7 @@ class TestAlert(TestCase):
         assert alert.inactive is True
         assert alert.disabled is False
         assert alert.rule_expression == "((responseTime >= 300 ms))"
-        assert alert.type.value == "HTTP Server"
-        assert alert.type.name == "HTTP_SERVER"
-        assert alert.type == AlertType("HTTP Server")
+        assert alert.type == "HTTP Server"
         assert alert.string_type == "HTTP Server"
         assert alert.date_start is None
         assert alert.date_end is None

--- a/thousandeyessdk/alert.py
+++ b/thousandeyessdk/alert.py
@@ -134,14 +134,6 @@ class Alert(BaseEntity):
         return self._data.get('type')
 
     @property
-    def test_targets_description(self):
-        """this key is not valid for alert object,
-        testTargetsDescription exists in webhook alert object only
-        This property will be deprecated in stable release        
-        """
-        return self._data.get('testTargetsDescription', [])
-
-    @property
     def rule(self) -> AlertRule:
         """WARNING: this property is sending another API to /alert-rules endpoint
                  If you need to get just a ruleId then use 'rule_id' property instead


### PR DESCRIPTION
[https://jira-eng-rtp2.cisco.com/jira/browse/SSE-1527](https://jira-eng-rtp2.cisco.com/jira/browse/SSE-1527)